### PR TITLE
Create single-file provider plugin binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ package-lock.json
 **/version.txt
 **/dist
 nuget/
+**/build
 
 ci-scripts/
 *.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build_provider:: ensure
 install_provider:: build_provider
 
 # builds all providers required for publishing
-build_artifacts:: ensure
+artifacts:: ensure
 	pushd provider/cmd/${PROVIDER}/ && \
 		yarn install && \
 	popd && \

--- a/Makefile
+++ b/Makefile
@@ -28,26 +28,27 @@ build_provider:: ensure
 	pushd provider/cmd/${PROVIDER}/ && \
 		yarn install && \
 	popd && \
-	rm -rf dist && npx --package @vercel/ncc ncc build provider/cmd/${PROVIDER}/index.ts -o dist -m && \
-	sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./dist/index.js && \
-	rm ./dist/index.js.bak && \
+	rm -rf build && npx --package @vercel/ncc ncc build provider/cmd/${PROVIDER}/index.ts -o build && \
+	sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./build/index.js && \
+	rm ./build/index.js.bak && \
 	rm -rf ./bin && mkdir bin && \
-	npx nexe dist/index.js -t $(target) -o bin/${PROVIDER}
+	npx nexe build/index.js -t $(target) -o bin/${PROVIDER}
 
 install_provider:: build_provider
 
 # builds all providers required for publishing
-artifacts:: ensure
+dist:: ensure
 	pushd provider/cmd/${PROVIDER}/ && \
 		yarn install && \
 	popd && \
-	rm -rf dist && npx --package @vercel/ncc ncc build provider/cmd/${PROVIDER}/index.ts -o dist -m && \
-	sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./dist/index.js && \
-	rm ./dist/index.js.bak && \
+	rm -rf build && npx --package @vercel/ncc ncc build provider/cmd/${PROVIDER}/index.ts -o build && \
+	sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./build/index.js && \
+	rm ./build/index.js.bak && \
+	rm -rf dist  && mkdir dist && \
 	for TARGET in "darwin-amd64" "win-amd64" "linux-amd64"; do \
 		rm -rf ./bin && mkdir bin && \
-		npx nexe dist/index.js -t "$${TARGET}-14.15.3" -o bin/${PROVIDER} && \
-		tar -czvf "$(PROVIDER)-v$(VERSION)-$${TARGET}.tar.gz" bin; \
+		npx nexe build/index.js -t "$${TARGET}-14.15.3" -o bin/${PROVIDER} && \
+		tar -czvf "dist/$(PROVIDER)-v$(VERSION)-$${TARGET}.tar.gz" bin; \
 	done
 
 # Go SDK

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A code generator is available which generates SDKs in TypeScript, Python, Go and
 
 An example of using the `StaticPage` component in TypeScript is in `examples/simple`.
 
-Note that the provider plugin (`pulumi-resource-xyz`) must be on your `PATH` to be used by Pulumi deployments. In this case, `pulumi-resource-xyz` is a platform-specific binary that includes its nodejs dependency along with the provider code, created using [nexe](https://github.com/nexe/nexe). By default, running `make install` will create the binary specific to your host environment, but you can override the binary target by passing in `make install target=<targe-string>` where `target-string` is a [valid nexe target](https://github.com/nexe/nexe#target-string--object).
+Note that the provider plugin (`pulumi-resource-xyz`) must be on your `PATH` to be used by Pulumi deployments. In this case, `pulumi-resource-xyz` is a platform-specific binary that includes its Node.js dependency along with the provider code, created using [nexe](https://github.com/nexe/nexe). By default, running `make install` will create the binary specific to your host environment, but you can override the binary target by passing in `make install target=<targe-string>` where `target-string` is a [valid nexe target](https://github.com/nexe/nexe#target-string--object).
 
 After running `make install`, `pulumi-resource-xyz` will be available in the `./bin` directory. You can add this to your path in bash with `export PATH=$PATH:$PWD/bin`.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ While the provider plugin must follow this naming convention, the SDK package na
 
 The provider plugin can be packaged into a tarball and hosted at a custom server URL to make it easier to distribute to users.
 
-Currently, three tarball files are necessary for Linux, macOS, and Windows (`pulumi-resource-xyz-v0.0.1-linux-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-darwin-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-windows-amd64.tar.gz`) each containing the same file: the platform-specific binary `pulumi-resource-xyz` created in the `./bin` directory after running `make install_provider`. These artifacts can be generated automatically using `make artifacts`.
+Currently, three tarball files are necessary for Linux, macOS, and Windows (`pulumi-resource-xyz-v0.0.1-linux-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-darwin-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-windows-amd64.tar.gz`) each containing the same file: the platform-specific binary `pulumi-resource-xyz` created in the `./bin` directory after running `make install_provider`. These artifacts can be generated automatically in the `dist` directory using `make dist`.
 
 TODO explain custom server hosting in more detail.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ A code generator is available which generates SDKs in TypeScript, Python, Go and
 
 An example of using the `StaticPage` component in TypeScript is in `examples/simple`.
 
-Note that the provider plugin (`pulumi-resource-xyz`) must be on your `PATH` to be used by Pulumi deployments. In this case, `pulumi-resource-xyz` is a simple bash script which invokes `node` to run the provider (there is also a `pulumi-resource-xyz.cmd` script that Pulumi will use on Windows). After running `make install`, `pulumi-resource-xyz` (and `pulumi-resource-xyz.cmd`) will be available in the `./bin` directory along with the JavaScript files and dependencies needed by the provider. You can add this to your path in bash with `export PATH=$PATH:$PWD/bin`.
+Note that the provider plugin (`pulumi-resource-xyz`) must be on your `PATH` to be used by Pulumi deployments. In this case, `pulumi-resource-xyz` is a platform-specific binary that includes its nodejs dependency along with the provider code, created using [nexe](https://github.com/nexe/nexe). By default, running `make install` will create the binary specific to your host environment, but you can override the binary target by passing in `make install target=<targe-string>` where `target-string` is a [valid nexe target](https://github.com/nexe/nexe#target-string--object).
+
+After running `make install`, `pulumi-resource-xyz` will be available in the `./bin` directory. You can add this to your path in bash with `export PATH=$PATH:$PWD/bin`.
 
 If creating a provider for distribution to other users, they will need `pulumi-resource-xyz` directory on their `PATH`. See the Packaging section below for more on distributing the provider to users.
 
@@ -55,9 +57,9 @@ While the provider plugin must follow this naming convention, the SDK package na
 
 The provider plugin can be packaged into a tarball and hosted at a custom server URL to make it easier to distribute to users.
 
-Currently three tarball files are necessary for Linux, macOS, and Windows (`pulumi-resource-xyz-v0.0.1-linux-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-darwin-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-windows-amd64.tar.gz`) each containing the same set of files: the content of the `./bin` directory after running `make install_provider`, excluding the `node_modules` directory. The `node_modules` directory isn't necessary to be included in the tarballs because the `PulumiPlugin.yaml` file indicates to Pulumi that this is a `nodejs` plugin that needs its `npm` dependencies installed as part of installing the plugin.
+Currently, three tarball files are necessary for Linux, macOS, and Windows (`pulumi-resource-xyz-v0.0.1-linux-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-darwin-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-windows-amd64.tar.gz`) each containing the same file: the platform-specific binary `pulumi-resource-xyz` created in the `./bin` directory after running `make install_provider`. These artifacts can be generated automatically using `make build_artifacts`
 
-TODO add make target to generate tarballs and explain custom server hosting in more detail.
+TODO explain custom server hosting in more detail.
 
 ## Example component
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ While the provider plugin must follow this naming convention, the SDK package na
 
 The provider plugin can be packaged into a tarball and hosted at a custom server URL to make it easier to distribute to users.
 
-Currently, three tarball files are necessary for Linux, macOS, and Windows (`pulumi-resource-xyz-v0.0.1-linux-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-darwin-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-windows-amd64.tar.gz`) each containing the same file: the platform-specific binary `pulumi-resource-xyz` created in the `./bin` directory after running `make install_provider`. These artifacts can be generated automatically using `make build_artifacts`
+Currently, three tarball files are necessary for Linux, macOS, and Windows (`pulumi-resource-xyz-v0.0.1-linux-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-darwin-amd64.tar.gz`, `pulumi-resource-xyz-v0.0.1-windows-amd64.tar.gz`) each containing the same file: the platform-specific binary `pulumi-resource-xyz` created in the `./bin` directory after running `make install_provider`. These artifacts can be generated automatically using `make artifacts`.
 
 TODO explain custom server hosting in more detail.
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@vercel/ncc": "^0.28.6",
+    "nexe": "^4.0.0-beta.18"
+  }
+}

--- a/provider/cmd/pulumi-resource-xyz/PulumiPlugin.yaml
+++ b/provider/cmd/pulumi-resource-xyz/PulumiPlugin.yaml
@@ -1,1 +1,0 @@
-runtime: nodejs

--- a/provider/cmd/pulumi-resource-xyz/pulumi-resource-xyz
+++ b/provider/cmd/pulumi-resource-xyz/pulumi-resource-xyz
@@ -1,3 +1,0 @@
-#!/bin/bash
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-node $SCRIPT_DIR $@

--- a/provider/cmd/pulumi-resource-xyz/pulumi-resource-xyz.cmd
+++ b/provider/cmd/pulumi-resource-xyz/pulumi-resource-xyz.cmd
@@ -1,4 +1,0 @@
-@echo off
-setlocal
-set SCRIPT_DIR=%~dp0
-@node "%SCRIPT_DIR%" %*


### PR DESCRIPTION
## Description

This PR primarily changes the plugin output to be a single platform-specific binary rather than an entire nodejs project with associated `node_modules`. To do this, we use [@vercel/ncc](https://www.npmjs.com/package/@vercel/ncc) to transpile the typescript project into a single index.js file and [nexe](https://github.com/nexe/nexe) to package the file created by ncc along with a nodejs binary into a single executable.

In doing so, the plugin goes from 212MB and thousands of files with an external dependency on nodejs to a single 85MB file with no external dependencies.

The PR also adds a `make artifacts` target to generate the tarballs required for publishing.

Related: https://github.com/pulumi/pulumi/issues/7009