### PR TITLE
feat: apple m1 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build_provider:: ensure
 	sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./build/index.js && \
 	rm ./build/index.js.bak && \
 	rm -rf ./bin && mkdir bin && \
-	npx nexe build/index.js -t $(target) -o bin/${PROVIDER}
+	npx nexe build/index.js -t $(target) -o bin/${PROVIDER} --build
 
 install_provider:: build_provider
 
@@ -45,9 +45,9 @@ dist:: ensure
 	sed -i.bak -e "s/\$${VERSION}/$(VERSION)/g" ./build/index.js && \
 	rm ./build/index.js.bak && \
 	rm -rf dist  && mkdir dist && \
-	for TARGET in "darwin-amd64" "win-amd64" "linux-amd64"; do \
+	for TARGET in "darwin-arm64" "darwin-amd64" "win-amd64" "linux-amd64"; do \
 		rm -rf ./bin && mkdir bin && \
-		npx nexe build/index.js -t "$${TARGET}-14.15.3" -o bin/${PROVIDER} && \
+		npx nexe build/index.js -t "$${TARGET}-14.15.3" -o bin/${PROVIDER} --build && \
 		tar -czvf "dist/$(PROVIDER)-v$(VERSION)-$${TARGET}.tar.gz" bin; \
 	done
 


### PR DESCRIPTION
Updates the makefile to support apple m1.

1. Tells nexe to compile node rather than download a precompiled binary (since arm64 binaries are not provided).
2. Compiles an additional pulumi plugin using arm64 architecture.