### PR TITLE
adjust ts version to make ncc happy

### DIFF
--- a/provider/cmd/pulumi-resource-xyz/package.json
+++ b/provider/cmd/pulumi-resource-xyz/package.json
@@ -6,6 +6,6 @@
     },
     "devDependencies": {
         "@types/node": "^10.0.0",
-        "typescript": "^4.0.0"
+        "typescript": "~4.6.0"
     }
 }


### PR DESCRIPTION
Using the latest minor version of ts is causing errors when running `build_provider` target when ncc is run.  It produces the following error:
```
ncc: Using typescript@4.7.2 (local user-provided)
Error: Module build failed (from ../../.npm/_npx/43481/lib/node_modules/@vercel/ncc/dist/ncc/loaders/ts-loader.js):
Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.
    at Object.resolveTypeReferenceDirective (/home/work/pulumi/pulumi-aws-static-website/provider/cmd/pulumi-resource-aws-static-website/node_modules/typescript/lib/typescript.js:42530:18)
    at /home/work/.npm/_npx/43481/lib/node_modules/@vercel/ncc/dist/ncc/loaders/ts-loader.js.cache.js:13:316837
    at /home/work/.npm/_npx/43481/lib/node_modules/@vercel/ncc/dist/ncc/loaders/ts-loader.js.cache.js:13:303785
    at Array.map (<anonymous>)
    at Object.resolveTypeReferenceDirectives (/home/work/.npm/_npx/43481/lib/node_modules/@vercel/ncc/dist/ncc/loaders/ts-loader.js.cache.js:13:303777)
    at actualResolveTypeReferenceDirectiveNamesWorker (/home/work/pulumi/pulumi-aws-static-website/provider/cmd/pulumi-resource-aws-static-website/node_modules/typescript/lib/typescript.js:116611:163)
    at resolveTypeReferenceDirectiveNamesWorker (/home/work/pulumi/pulumi-aws-static-website/provider/cmd/pulumi-resource-aws-static-website/node_modules/typescript/lib/typescript.js:116911:26)
    at processTypeReferenceDirectives (/home/work/pulumi/pulumi-aws-static-website/provider/cmd/pulumi-resource-aws-static-website/node_modules/typescript/lib/typescript.js:118393:31)
    at findSourceFileWorker (/home/work/pulumi/pulumi-aws-static-website/provider/cmd/pulumi-resource-aws-static-website/node_modules/typescript/lib/typescript.js:118278:21)
    at findSourceFile (/home/work/pulumi/pulumi-aws-static-website/provider/cmd/pulumi-resource-aws-static-website/node_modules/typescript/lib/typescript.js:118133:26)
    at /home/work/.npm/_npx/43481/lib/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:37:1770552
    at /home/work/.npm/_npx/43481/lib/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:37:374702
    at _done (eval at create (/home/work/.npm/_npx/43481/lib/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:20:75523), <anonymous>:7:1)
    at eval (eval at create (/home/work/.npm/_npx/43481/lib/node_modules/@vercel/ncc/dist/ncc/index.js.cache.js:20:75523), <anonymous>:32:22)
make: *** [Makefile:30: build_provider] Error 1

```

This adjusts the package.json in the example boilerplate provider to just take the latest patch of 4.6. 