### PR TITLE
Require at least pulumi version 3.34.1

### DIFF
--- a/provider/cmd/pulumi-resource-xyz/package.json
+++ b/provider/cmd/pulumi-resource-xyz/package.json
@@ -2,7 +2,7 @@
     "version": "${VERSION}",
     "bin": "bin/index.js",
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/pulumi": "^3.34.1",
         "@pulumi/aws": "^4.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Resolves an issue with pkg where warnings are printed due to the inspector not being available in binary packages.