### PR TITLE
Fix a bug in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,6 @@ build_python_sdk:: gen_python_sdk
 	cd sdk/python/ && \
 		python3 setup.py clean --all 2>/dev/null && \
 		rm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \
-		sed -i.bak -e "s/\$${VERSION}/${PYPI_VERSION}/g" -e "s/\$${PLUGIN_VERSION}/${VERSION}/g" ./bin/setup.py && \
+		sed -i.bak -e 's/^VERSION = .*/VERSION = "$(PYPI_VERSION)"/g' -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "$(VERSION)"/g' ./bin/setup.py && \
 		rm ./bin/setup.py.bak && \
 		cd ./bin && python3 setup.py build sdist


### PR DESCRIPTION
Noticed this after a few publishing attempts failed on trying to publish version `0.0.0`. This code was taken from the Go boilerplate repo: https://github.com/pulumi/pulumi-component-provider-go-boilerplate/blob/35ca77c70fd66189bc16f010e6cb0d98f1c53acc/Makefile#L90

If this is correct, we should probably propagate to the other boilerplate repos as well. (Looks like the Python repo has the same issue.)