### PR TITLE
Fix: bumping typescript version to 4.6.3

### DIFF
--- a/provider/cmd/pulumi-resource-xyz/package.json
+++ b/provider/cmd/pulumi-resource-xyz/package.json
@@ -8,6 +8,6 @@
     "devDependencies": {
         "@types/node": "^10.0.0",
         "pkg": "^5.6.0",
-        "typescript": "^4.0.0"
+        "typescript": "^4.6.3"
     }
 }

--- a/schema.json
+++ b/schema.json
@@ -46,7 +46,7 @@
                 "@pulumi/aws": "^5.0.0"
             },
             "devDependencies": {
-                "typescript": "^3.7.0"
+                "typescript": "^4.6.3"
             },
             "respectSchemaVersion": true
         },

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -8,7 +8,7 @@
         "@pulumi/aws": "^4.0.0"
     },
     "devDependencies": {
-        "typescript": "^3.7.0"
+        "typescript": "^4.6.3"
     },
     "peerDependencies": {
         "@pulumi/pulumi": "latest"


### PR DESCRIPTION
It was pointed out on the pulumi slack community channel that (https://pulumi-community.slack.com/archives/CJ909TL6P/p1699371314025259)

`make install_nodejs_sdk` fails with error - 

```
yarn run v1.22.19
warning package.json: No license field
$ /Users/hrushikeshchoudhary/pulumi/pulumi-aws-vanta/sdk/nodejs/node_modules/.bin/tsc
node_modules/@types/node/ts4.8/test.d.ts:876:34 - error TS1005: '?' expected.

876             : F extends abstract new(...args: any) => infer T ? T
                                     ~~~

node_modules/@types/node/ts4.8/test.d.ts:876:63 - error TS1005: ':' expected.

876             : F extends abstract new(...args: any) => infer T ? T
                                                                  ~

node_modules/@types/node/ts4.8/test.d.ts:877:13 - error TS1005: ',' expected.

877             : unknown,
                ~

node_modules/@types/node/ts4.8/test.d.ts:879:34 - error TS1005: '?' expected.

879             : F extends abstract new(...args: infer Y) => any ? Y
                                     ~~~

node_modules/@types/node/ts4.8/test.d.ts:879:63 - error TS1005: ':' expected.

879             : F extends abstract new(...args: infer Y) => any ? Y
                                                                  ~

node_modules/@types/node/ts4.8/test.d.ts:880:13 - error TS1005: ',' expected.

880             : unknown[],
                ~

node_modules/@types/node/ts4.8/test.d.ts:880:22 - error TS1005: ',' expected.

880             : unknown[],
                         ~

node_modules/@types/node/ts4.8/test.d.ts:881:5 - error TS1109: Expression expected.

881     > {
        ~

node_modules/@types/node/ts4.8/test.d.ts:885:24 - error TS1005: ',' expected.

885         arguments: Args;
                           ~

node_modules/@types/node/ts4.8/test.d.ts:889:35 - error TS1005: ',' expected.

889         error: unknown | undefined;
                                      ~

node_modules/@types/node/ts4.8/test.d.ts:895:39 - error TS1005: ',' expected.

895         result: ReturnType | undefined;
                                          ~

node_modules/@types/node/ts4.8/test.d.ts:899:21 - error TS1005: ',' expected.

899         stack: Error;
                        ~

node_modules/@types/node/ts4.8/test.d.ts:904:19 - error TS1005: ',' expected.

904         target: F extends abstract new(...args: any) => any ? F : undefined;
                      ~~~~~~~

node_modules/@types/node/ts4.8/test.d.ts:904:27 - error TS1005: ':' expected.

904         target: F extends abstract new(...args: any) => any ? F : undefined;
                              ~~~~~~~~

node_modules/@types/node/ts4.8/test.d.ts:904:36 - error TS1005: ',' expected.

904         target: F extends abstract new(...args: any) => any ? F : undefined;
                                       ~~~

node_modules/@types/node/ts4.8/test.d.ts:904:54 - error TS1005: '{' expected.

904         target: F extends abstract new(...args: any) => any ? F : undefined;
                                                         ~~

node_modules/@types/node/ts4.8/test.d.ts:904:63 - error TS1005: ',' expected.

904         target: F extends abstract new(...args: any) => any ? F : undefined;
                                                                  ~

node_modules/@types/node/ts4.8/test.d.ts:904:76 - error TS1005: ',' expected.

904         target: F extends abstract new(...args: any) => any ? F : undefined;
                                                                               ~

node_modules/@types/node/ts4.8/test.d.ts:908:22 - error TS1005: ',' expected.

908         this: unknown;
                         ~


Found 19 errors.

error Command failed with exit code 2.
```

Turns out typescript 3.9.0 is no longer supported by DefinitelyTyped (@types/node)

More Details on this thread: https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/64262#discussioncomment-5101104