### PR TITLE
Update release.yml template to install setuptools

### DIFF
--- a/deployment-templates/release.yml
+++ b/deployment-templates/release.yml
@@ -99,6 +99,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{matrix.pythonversion}}
+      - name: Install setuptools
+        run: pip install setuptools
       - name: Build SDK
         run: make build_${{ matrix.language }}_sdk
       - name: Check worktree clean


### PR DESCRIPTION
setuptools is no longer install by default for python versions >=3.12 so the template should install it (as the python sdk build requires it.)
Fixes #56 